### PR TITLE
Fix README example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 NAVT(Network Address Vlan Translation) with XDP
 
 VID:100, 192.168.0.1(inside) <=> VID:98, 10.10.0.1 (outside)  
-VID:1500, 192.168.0.1(inside0 <=> VID:98, 10.15.0.1(outside)
+VID:1500, 192.168.0.1(inside) <=> VID:98, 10.15.0.1 (outside)
 
 ## Build
 In today's Linux, bpf_helper_defs.h is supposed to build.


### PR DESCRIPTION
## Summary
- fix closing parenthesis typo in the README example
- adjust spacing around the outside address in VLAN mapping

## Testing
- `go generate ./...` *(passes)*
- `make test` *(fails: operation not permitted for eBPF due to MEMLOCK limit)*

------
https://chatgpt.com/codex/tasks/task_e_686766705b58832192eae6817fb689a5